### PR TITLE
Fixed "Kernel Settings" tab layout (bnc#865366)

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 25 10:17:36 CET 2014 - locilka@suse.com
+
+- Fixed "Kernel Settings" tab layout (bnc#865366)
+- 3.1.2
+
+-------------------------------------------------------------------
 Wed Jan 22 09:46:23 UTC 2014 - lslezak@suse.cz
 
 - removed "Save to Floppy" option (nobody uses floppies anymore...)

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        3.1.1
+Version:        3.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/hwinfo/system_settings_dialogs.rb
+++ b/src/include/hwinfo/system_settings_dialogs.rb
@@ -43,10 +43,13 @@ module Yast
         },
         "kernel_settings" => {
           "header"       => _("Kernel Settings"),
-          "contents"     => HBox(
-            HSpacing(1),
-            VBox(VSpacing(0.3), Left("elevator"), VSpacing(1), Left("sysrq")),
-            HSpacing(1)
+          "contents"     => VBox(
+            HBox(
+              HSpacing(1),
+              VBox(VSpacing(0.3), Left("elevator"), VSpacing(1), Left("sysrq")),
+              HSpacing(1)
+            ),
+            VStretch()
           ),
           "widget_names" => ["elevator", "sysrq"]
         }


### PR DESCRIPTION
I've just added one VStretch at the bottom of the dialog. The dialog used to be centered vertically but that breaks installation layout as it tries to shrink everything and thus the dialog tab was lower than expected.
