### PR TITLE
appstream: install metainfo.xml file

### DIFF
--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -83,7 +83,8 @@ fi
 
 %files
 %defattr(-,root,root)
-
+%dir %{_datadir}/appdata
+%{_datadir}/appdata/%{name}.metainfo.xml
 %{yast_yncludedir}/hwinfo/*
 %{yast_clientdir}/*.rb
 %{yast_desktopdir}/hwinfo.desktop

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,10 @@ desktop_DATA = \
   desktop/system_settings.desktop \
   desktop/hwinfo.desktop
 
-EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(desktop_DATA)
+metainfodir = $(datadir)/appdata
+metainfo_DATA = \
+  metainfo/yast2-tune.metainfo.xml
+
+EXTRA_DIST = $(module_DATA) $(client_DATA) $(ynclude_DATA) $(scrconf_DATA) $(desktop_DATA) $(metainfo_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/src/metainfo/yast2-tune.metainfo.xml
+++ b/src/metainfo/yast2-tune.metainfo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2015 Dominique Leuenberger <dimstar@opensuse.org> -->
+<component type="addon">
+<id>yast2-tune</id>
+<extends>yast2.desktop</extends>
+<name>Hardware Information</name>
+<summary>View hardware information</summary>
+<url type="homepage">https://github.com/yast/yast-tune</url>
+<metadata_license>CC0-1.0</metadata_license>
+<project_license>GPL-2.0</project_license>
+<updatecontact>yast-devel@opensuse.org</updatecontact>
+</component>


### PR DESCRIPTION
Hope that is all right... 

basing it off the .desktop file(s) looks much more complex and with little value, as only the Name/Summary is really there...

preferably, each .desktop file with it's metainfo.xml should be living in a sep. package (no collection of plugins, as enabling one in g-s will 'enable multiple' - and more confusing so on uninstalling a plugin)

If the .desktops happen to be split across multiple rpm, it get's more confusing, as the ID in the metainfo.xml has to refer to the package name the .desktop file lives in.

Hence, I believe that a manual import of this simplostic xml file would be more suitable