### PR TITLE
Fixed scheduler activation (bsc#1052770)

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 14 18:19:47 UTC 2017 - lslezak@suse.cz
+
+- Fixed scheduler activation: do not activate the new scheduler
+  for devices which do not support it (bsc#1052770)
+- 3.3.0
+
+-------------------------------------------------------------------
 Fri Jan 20 16:21:30 UTC 2017 - mvidner@suse.com
 
 - Added Tune::Widgets::SystemInformation (FATE#322328).

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        3.2.0
+Version:        3.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
- Fixes https://bugzilla.suse.com/show_bug.cgi?id=1052770
- Do not activate the new scheduler for devices which do not support it. Activating an unsupported scheduler results in a write error.
- 3.3.0