### PR TITLE
Removed duplicate keys (bsc#1054898)

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep  5 14:19:50 UTC 2017 - lslezak@suse.cz
+
+- Removed duplicate keys (bsc#1054898)
+- 4.0.0
+
+-------------------------------------------------------------------
 Mon Aug 14 18:19:47 UTC 2017 - lslezak@suse.cz
 
 - Fixed scheduler activation: do not activate the new scheduler

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        3.3.0
+Version:        4.0.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/hwinfo/routines.rb
+++ b/src/include/hwinfo/routines.rb
@@ -37,11 +37,6 @@ module Yast
             "yast-hardware"
           ],
           # tree node string
-          "cache"                      => [
-            _("Cache"),
-            "yast-hardware"
-          ],
-          # tree node string
           "card_type"                  => [
             _("Card Type"),
             "yast-hardware"
@@ -334,11 +329,6 @@ module Yast
           # tree node string
           "vendor"                     => [
             _("Vendor"),
-            "yast-x11"
-          ],
-          # tree node string
-          "vendor_id"                  => [
-            _("Vendor Identifier"),
             "yast-x11"
           ],
           # tree node string
@@ -970,7 +960,6 @@ module Yast
       if Ops.is_list?(node)
         # if node is list ...
         lout = []
-        q = Builtins.size(Convert.to_list(node))
         pos = 0
         Builtins.foreach(Convert.to_list(node)) do |e|
           if scalar(e)


### PR DESCRIPTION
- Fixes issue
```
/mounts/mp_0001/usr/share/YaST2/include/hwinfo/routines.rb:43: warning: key "cache" is duplicated and overwritten on line 592
/mounts/mp_0001/usr/share/YaST2/include/hwinfo/routines.rb:343: warning: key "vendor_id" is duplicated and overwritten on line 652
```
- See https://bugzilla.suse.com/show_bug.cgi?id=1054670
- The `cache` key was also defined [at line 592](https://github.com/yast/yast-tune/blob/14ed6d22bdd193916928dcdd709cd4cb91ce4bf9/src/include/hwinfo/routines.rb#L592)
- The `vendor_id` key was also defined [at line 652](https://github.com/yast/yast-tune/blob/14ed6d22bdd193916928dcdd709cd4cb91ce4bf9/src/include/hwinfo/routines.rb#L652)
- Fixed additional warning `assigned but unused variable - q`
- 4.0.0