### PR TITLE
Write sysctl settings to /etc/sysctl.d

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct  4 13:30:49 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Place sysctl settings in /etc/sysctl.d/ (jsc#SLE-9077).
+- 4.2.1
+
+-------------------------------------------------------------------
 Fri May 31 12:41:37 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Add metainfo (fate#319035)

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        4.2.0
+Version:        4.2.1
 Release:        0
 Summary:        YaST2 - Hardware Tuning
 License:        GPL-2.0-or-later
@@ -27,12 +27,12 @@ Url:            https://github.com/yast/yast-tune
 Source0:        %{name}-%{version}.tar.bz2
 
 BuildRequires:  update-desktop-files
-BuildRequires:  yast2
+# CFA::Sysctl
+BuildRequires:  yast2 >= 4.2.25
 BuildRequires:  yast2-devtools >= 4.2.2
 
-# hwinfo/classnames.ycp
-# Wizard::SetDesktopTitleAndIcon
-Requires:       yast2 >= 2.21.22
+# CFA::Sysctl
+Requires:       yast2 >= 4.2.25
 Requires:       yast2-bootloader
 Requires:       yast2-ruby-bindings >= 1.0.0
 

--- a/test/system_settings_test.rb
+++ b/test/system_settings_test.rb
@@ -10,12 +10,16 @@ describe "Yast::SystemSettings" do
 
   subject(:settings) { Yast::SystemSettings }
   let(:scheduler)     { "cfq" }
+  let(:sysctl_file) { CFA::Sysctl.new }
 
   before do
     allow(File).to receive(:exist?).and_return(true)
     allow(Yast::Bootloader).to receive(:Read)
     allow(Yast::Bootloader).to receive(:kernel_param)
       .with(:common, "elevator").and_return(scheduler)
+    allow(CFA::Sysctl).to receive(:new).and_return(sysctl_file)
+    allow(sysctl_file).to receive(:load)
+    allow(sysctl_file).to receive(:save)
     settings.main
   end
 
@@ -30,9 +34,7 @@ describe "Yast::SystemSettings" do
     let(:sysctl_sysrq)  { "1" }
 
     before do
-      allow(Yast::SCR).to receive(:Read)
-        .with(Yast::Path.new(".etc.sysctl_conf.\"kernel.sysrq\""))
-        .and_return(sysctl_sysrq)
+      allow(sysctl_file).to receive(:kernel_sysrq).and_return(sysctl_sysrq)
       allow(File).to receive(:read).with(KERNEL_SYSRQ_FILE)
         .and_return(kernel_sysrq)
       allow(Yast::Bootloader).to receive(:kernel_param)
@@ -219,9 +221,7 @@ describe "Yast::SystemSettings" do
       allow(Yast::Mode).to receive(:mode).and_return(mode)
       allow(Yast::Bootloader).to receive(:Write)
       allow(Yast::SCR).to receive(:Read).and_call_original
-      allow(Yast::SCR).to receive(:Read)
-        .with(Yast::Path.new(".etc.sysctl_conf.\"kernel.sysrq\""))
-        .and_return(sysctl_sysrq)
+      allow(sysctl_file).to receive(:kernel_sysrq).and_return(sysctl_sysrq)
     end
 
     context "when system settings has been read" do
@@ -231,10 +231,7 @@ describe "Yast::SystemSettings" do
         let(:sysctl_sysrq) { "0" }
 
         it "updates sysctl configuration" do
-          expect(Yast::SCR).to receive(:Write)
-            .with(Yast::Path.new(".etc.sysctl_conf.\"kernel.sysrq\""), sysctl_sysrq)
-          expect(Yast::SCR).to receive(:Write)
-            .with(Yast::Path.new(".etc.sysctl_conf"), nil)
+          expect(sysctl_file).to receive(:kernel_sysrq=).with(sysctl_sysrq)
           settings.Write
         end
       end
@@ -243,8 +240,7 @@ describe "Yast::SystemSettings" do
         let(:sysctl_sysrq) { "-1" }
 
         it "does not update sysctl configuration" do
-          expect(Yast::SCR).to_not receive(:Write)
-            .with(Yast::Path.new(".etc.sysctl_conf.\"kernel.sysrq\""), sysctl_sysrq)
+          expect(sysctl_file).to_not receive(:kernel_sysrq=)
           settings.Write
         end
       end
@@ -266,8 +262,7 @@ describe "Yast::SystemSettings" do
 
     context "when system settings hadn't been read" do
       it "does not update sysctl configuration" do
-        expect(Yast::SCR).to_not receive(:Write)
-          .with(Yast::Path.new(".etc.sysctl_conf.\"kernel_sysrq\""), anything)
+        expect(sysctl_file).to_not receive(:kernel_sysrq=)
         settings.Write
       end
     end
@@ -309,9 +304,7 @@ describe "Yast::SystemSettings" do
   describe "#SetSysRqKeysEnabled" do
     before do
       allow(Yast::SCR).to receive(:Read).and_call_original
-      allow(Yast::SCR).to receive(:Read)
-        .with(Yast::Path.new(".etc.sysctl_conf.\"kernel.sysrq\""))
-        .and_return(sysctl_sysrq)
+      allow(sysctl_file).to receive(:kernel_sysrq).and_return(sysctl_sysrq)
       settings.Read
     end
 


### PR DESCRIPTION
Adapts sysctl handling to use the new [CFA::Sysctl](https://github.com/yast/yast-yast2/pull/966) class so the configuration is written to a YaST specific file under `/etc/sysctl.d`.