### PR TITLE
Abort when bootloader cannot be read

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 26 16:38:08 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Abort the execution when the bootloader cannot be read
+  (related to bsc#to bsc#1137688).
+- 4.2.2
+
+-------------------------------------------------------------------
 Fri Oct  4 13:30:49 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Place sysctl settings in /etc/sysctl.d/ (jsc#SLE-9077).

--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -2,7 +2,7 @@
 Tue Nov 26 16:38:08 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Abort the execution when the bootloader cannot be read
-  (related to bsc#to bsc#1137688).
+  (related to bsc#1137688).
 - 4.2.2
 
 -------------------------------------------------------------------

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - Hardware Tuning
 License:        GPL-2.0-or-later

--- a/src/include/hwinfo/system_settings_ui.rb
+++ b/src/include/hwinfo/system_settings_ui.rb
@@ -58,7 +58,9 @@ module Yast
       # to avoid of the very long starting time of the yast module
       # because the Storage module (which is imported by the Bootloader (imported by the SystemSettings module))
       # has a Read() function call in its constructor.
-      SystemSettings.Read
+      system_settings = SystemSettings.Read
+      return :abort unless system_settings
+
       Progress.set(progress_orig)
 
       Progress.NextStage

--- a/src/include/hwinfo/system_settings_ui.rb
+++ b/src/include/hwinfo/system_settings_ui.rb
@@ -58,8 +58,10 @@ module Yast
       # to avoid of the very long starting time of the yast module
       # because the Storage module (which is imported by the Bootloader (imported by the SystemSettings module))
       # has a Read() function call in its constructor.
-      system_settings = SystemSettings.Read
-      return :abort unless system_settings
+
+      # Aborting without any message since SystemSettings.Read
+      # already reported the problem to the user
+      return :abort unless SystemSettings.Read
 
       Progress.set(progress_orig)
 

--- a/src/modules/SystemSettings.rb
+++ b/src/modules/SystemSettings.rb
@@ -56,7 +56,9 @@ module Yast
     # @see #read_scheduler
     def Read
       read_sysrq
-      read_scheduler
+      ret = read_scheduler
+
+      return false unless ret
       @modified = false
       true
     end
@@ -287,11 +289,17 @@ module Yast
     # @see Read
     def read_scheduler
       # Read bootloader settings in normal mode
-      Bootloader.Read if Mode.normal
+      if Mode.normal
+        bootloader_read = Bootloader.Read
+
+        return false unless bootloader_read
+      end
 
       # Set IO scheduler
       SetIOScheduler(current_elevator)
       log.info("Global IO scheduler: #{GetIOScheduler()}")
+
+      true
     end
 
     # Read SysRq keys configuration updating the module's value

--- a/src/modules/SystemSettings.rb
+++ b/src/modules/SystemSettings.rb
@@ -287,8 +287,11 @@ module Yast
     # Read IO scheduler configuration updating the module's value
     #
     # @see Read
+    #
+    # @return [Boolean] false if there is a problem reading the bootloader; true otherwise
     def read_scheduler
-      # Read bootloader settings in normal mode
+      # Try to read the bootloader settings in normal mode.
+      # If there is a problem, the user will be warned directly by the bootloader module.
       if Mode.normal
         bootloader_read = Bootloader.Read
 


### PR DESCRIPTION
## Original problem

When executed without enough privileges/permissions, it crash `Errno::EACCES` error when trying access to the _grub.cfg_ file.

* Trello card: https://trello.com/c/nhBiaGEa


![Screenshot_opensusetumbleweed_2019-11-25_18:18:27](https://user-images.githubusercontent.com/1691872/69566897-10e00900-0fb0-11ea-8d16-58176f398336.png)




However, this is actually a problem of `yast-bootloader`, and is being addresed in https://github.com/yast/yast-bootloader/pull/583

## _Current_ problem

The execution is not aborted nicely even after fix the original problem in `yast-booloader`. It simply shows the message to the user and continue the execution.

## Solution

Abort the execution when the bootloader cannot be readed.

## Tests

* Tested manually in a running system.
* Test suite updated

## Notes

:rotating_light: **Merge https://github.com/yast/yast-bootloader/pull/583 first**

---

Related to https://github.com/yast/yast-bootloader/pull/583