### PR TITLE
Backport scheduler fix

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,9 +1,10 @@
 -------------------------------------------------------------------
 Mon Aug 14 18:19:47 UTC 2017 - lslezak@suse.cz
 
-- Fixed scheduler activation: do not activate the new scheduler
-  for devices which do not support it (bsc#1052770)
-- 3.3.0
+- Backport: Fixed scheduler activation: do not activate the new
+  scheduler for devices which do not support it (bsc#1052770)
+  (backport request at bsc#1177035)
+- 3.2.1
 
 -------------------------------------------------------------------
 Fri Jan 20 16:21:30 UTC 2017 - mvidner@suse.com

--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug 14 18:19:47 UTC 2017 - lslezak@suse.cz
+
+- Fixed scheduler activation: do not activate the new scheduler
+  for devices which do not support it (bsc#1052770)
+- 3.3.0
+
+-------------------------------------------------------------------
 Fri Jan 20 16:21:30 UTC 2017 - mvidner@suse.com
 
 - Added Tune::Widgets::SystemInformation (FATE#322328).

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        3.3.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        3.2.0
+Version:        3.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
trello: https://trello.com/c/9Be85Hz8/2110-1-sles12-sp5-p3-1177035-setting-global-i-o-scheduler-during-installation-causes-invalid-argument-fptrfinalize-sys-block-loop15-q

bsc: https://bugzilla.suse.com/show_bug.cgi?id=1177035

original PR: https://github.com/yast/yast-tune/pull/27