### PR TITLE
remove elevator settings (bsc#1178797)

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 17 15:13:33 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- add I/O device autoconfig checkbox on s390 (bsc#1168036)
+- 4.2.4
+
+-------------------------------------------------------------------
 Mon Feb 24 15:10:14 CET 2020 - schubi@suse.de
 
 - Using SysctlConfig class: Handle sysctl entries in different

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        YaST2 - Hardware Tuning
 License:        GPL-2.0-or-later

--- a/src/include/hwinfo/system_settings_dialogs.rb
+++ b/src/include/hwinfo/system_settings_dialogs.rb
@@ -31,6 +31,17 @@ module Yast
 
       @contents = VBox("tab")
 
+      # whether to show I/O device autoconfig checkbox
+      has_autoconf = Arch.s390
+
+      kernel_widget_names = ["elevator", "sysrq"]
+      kernel_widgets = [VSpacing(0.3), Left("elevator"), VSpacing(1), Left("sysrq")]
+
+      if has_autoconf
+        kernel_widget_names << "autoconf"
+        kernel_widgets << VSpacing(1) << Left("autoconf")
+      end
+
       @tabs_descr = {
         "pci_id"          => {
           "header"       => NewPCIIDDialogCaption(),
@@ -46,12 +57,12 @@ module Yast
           "contents"     => VBox(
             HBox(
               HSpacing(1),
-              VBox(VSpacing(0.3), Left("elevator"), VSpacing(1), Left("sysrq")),
+              VBox(*kernel_widgets),
               HSpacing(1)
             ),
             VStretch()
           ),
-          "widget_names" => ["elevator", "sysrq"]
+          "widget_names" => kernel_widget_names
         }
       }
 
@@ -138,6 +149,17 @@ module Yast
               "Alt-SysRq-<command_key> will start the respective command (e.g. reboot the\n" +
               "computer, dump kernel information). For further information, see\n" +
               "<tt>/usr/src/linux/Documentation/sysrq.txt</tt> (package kernel-source).</p>\n"
+          )
+        },
+        "autoconf"                    => {
+          "widget" => :checkbox,
+          "label"  => _("Enable I/O device auto-configuration"),
+          "store"  => fun_ref(method(:StoreAutoConfSettings), "void (string, map)"),
+          "init"   => fun_ref(method(:InitAutoConfSettings), "void (string)"),
+          "help"   => _(
+            "<p><b><big>Enable I/O device auto-configuration</big></b><br>\n" +
+            "Disable <b>I/O device auto-configuration</b>\n" +
+            "if you don't want any existing I/O auto-configuration data to be applied.</p>\n"
           )
         }
       }

--- a/src/include/hwinfo/system_settings_dialogs.rb
+++ b/src/include/hwinfo/system_settings_dialogs.rb
@@ -34,8 +34,8 @@ module Yast
       # whether to show I/O device autoconfig checkbox
       has_autoconf = Arch.s390
 
-      kernel_widget_names = ["elevator", "sysrq"]
-      kernel_widgets = [VSpacing(0.3), Left("elevator"), VSpacing(1), Left("sysrq")]
+      kernel_widget_names = ["sysrq"]
+      kernel_widgets = [VSpacing(1), Left("sysrq")]
 
       if has_autoconf
         kernel_widget_names << "autoconf"
@@ -81,58 +81,6 @@ module Yast
           "handle"        => fun_ref(
             method(:HandleNewPCIIDDialog),
             "symbol (string, map)"
-          )
-        },
-        # /usr/src/linux/Documentation/kernel-parameters.txt
-        # http://www.redhat.com/magazine/008jun05/features/schedulers/
-        #
-        # elevator=    [IOSCHED]
-        #		Format: {"cfq"|"deadline"|"noop"}
-        #		See Documentation/block/as-iosched.txt
-        #		and Documentation/block/deadline-iosched.txt for details.
-        #
-        #	'deadline' =>	Deadline. Database servers, especially those using "TCQ" disks should
-        #			investigate performance with the 'deadline' IO scheduler. Any system with high
-        #			disk performance requirements should do so, in fact.
-        #	'noop' => NOOP
-        #	'cfq' => Completely Fair Queuing (the default)
-        "elevator"                 => {
-          "widget"        => :custom,
-          # combo box label
-          "custom_widget" => ComboBox(
-            Id("elevator"),
-            _("Global &I/O Scheduler"),
-            [
-              # combo box item - I/O scheduler
-              Item(Id(""), _("Not Configured")),
-              # combo box item - I/O scheduler, do not translate the abbreviation in brackets
-              Item(Id("cfq"), _("Completely Fair Queuing [cfq]")),
-              # combo box item - I/O scheduler, do not translate the abbreviation in brackets
-              Item(Id("noop"), _("NOOP [noop]")),
-              # combo box item - I/O scheduler, do not translate the abbreviation in brackets
-              Item(Id("deadline"), _("Deadline [deadline]"))
-            ]
-          ),
-          "handle"        => fun_ref(
-            method(:HandleElevatorSettings),
-            "symbol (string, map)"
-          ),
-          "init"          => fun_ref(
-            method(:InitElevatorSettings),
-            "void (string)"
-          ),
-          "store"         => fun_ref(
-            method(:StoreElevatorSettings),
-            "void (string, map)"
-          ),
-          # help text for the scheduler widget, do not translate 'cfq'
-          "help"          => _(
-            "<p><b><big>Global I/O Scheduler</big></b><br>\n" +
-              "Select the algorithm which orders and sends commands to disk\n" +
-              "devices. This is a global option, it will be used for all disk devices in the\n" +
-              "system. If the option is not configured, the default scheduler (usually 'cfq')\n" +
-              "will be used. See the documentation in the /usr/src/linux/Documentation/block\n" +
-              "directory (package kernel-source) for more information.</p>\n"
           )
         },
         # .sysconfig.sysctl

--- a/src/include/hwinfo/system_settings_ui.rb
+++ b/src/include/hwinfo/system_settings_ui.rb
@@ -119,30 +119,6 @@ module Yast
       :next
     end
 
-
-    def HandleElevatorSettings(key, event)
-      event = deep_copy(event)
-      Builtins.y2milestone("Key: %1, Event: %2", key, event)
-      nil
-    end
-
-    def InitElevatorSettings(value)
-      Wizard.DisableBackButton
-      UI.ChangeWidget(Id("elevator"), :Value, SystemSettings.GetIOScheduler)
-
-      nil
-    end
-
-    def StoreElevatorSettings(key, event)
-      event = deep_copy(event)
-      Builtins.y2milestone("Key: %1, Event: %2", key, event)
-      elevator_new = Convert.to_string(UI.QueryWidget(Id("elevator"), :Value))
-
-      SystemSettings.SetIOScheduler(elevator_new)
-
-      nil
-    end
-
     def InitSysRqSettings(key)
       Wizard.DisableBackButton
       UI.ChangeWidget(Id("sysrq"), :Value, SystemSettings.GetSysRqKeysEnabled)

--- a/src/include/hwinfo/system_settings_ui.rb
+++ b/src/include/hwinfo/system_settings_ui.rb
@@ -161,5 +161,24 @@ module Yast
 
       nil
     end
+
+    def InitAutoConfSettings(key)
+      Wizard.DisableBackButton
+      UI.ChangeWidget(Id("autoconf"), :Value, SystemSettings.GetAutoConf)
+
+      nil
+    end
+
+    def StoreAutoConfSettings(key, event)
+      event = deep_copy(event)
+      Builtins.y2milestone("Key: %1, Event: %2", key, event)
+
+      autoconf_new = Convert.to_boolean(UI.QueryWidget(Id("autoconf"), :Value))
+      if SystemSettings.GetAutoConf != autoconf_new
+        SystemSettings.SetAutoConf(autoconf_new)
+      end
+
+      nil
+    end
   end
 end

--- a/test/system_settings_test.rb
+++ b/test/system_settings_test.rb
@@ -10,6 +10,7 @@ describe "Yast::SystemSettings" do
 
   subject(:settings) { Yast::SystemSettings }
   let(:scheduler)     { "cfq" }
+  let(:rd_zdev)       { "no-auto" }
   let(:sysctl_config) { CFA::SysctlConfig.new }
 
   before do
@@ -17,6 +18,8 @@ describe "Yast::SystemSettings" do
     allow(Yast::Bootloader).to receive(:Read)
     allow(Yast::Bootloader).to receive(:kernel_param)
       .with(:common, "elevator").and_return(scheduler)
+    allow(Yast::Bootloader).to receive(:kernel_param)
+      .with(:common, "rd.zdev").and_return(rd_zdev)
     allow(CFA::SysctlConfig).to receive(:new).and_return(sysctl_config)
     allow(sysctl_config).to receive(:load)
     allow(sysctl_config).to receive(:save)
@@ -40,6 +43,8 @@ describe "Yast::SystemSettings" do
         .and_return(kernel_sysrq)
       allow(Yast::Bootloader).to receive(:kernel_param)
         .with(:common, "elevator").and_return(scheduler)
+      allow(Yast::Bootloader).to receive(:kernel_param)
+        .with(:common, "rd.zdev").and_return(rd_zdev)
       allow(Yast::Mode).to receive(:mode).and_return(mode)
     end
 
@@ -158,6 +163,7 @@ describe "Yast::SystemSettings" do
       allow(Yast::Bootloader).to receive(:modify_kernel_params)
       allow(Yast::Bootloader).to receive(:proposed_cfg_changed=)
       allow(Dir).to receive(:[]).with(/scheduler/).and_return([disk, disk2])
+      allow(Dir).to receive(:[]).with("/usr/share/YaST2/locale/*").and_return([])
     end
 
     context "when SysRq keys status is unknown" do


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1178797
- https://trello.com/c/P1DClkH3

Remove outdated `elevator` kernel option handling.

## Related

- https://github.com/yast/yast-tune/pull/46

## Screenshots
### on non-s390 systems
![q3](https://user-images.githubusercontent.com/927244/102508399-a059cd80-4085-11eb-9a41-2b0929ee1e39.jpg)
### on s390 systems
![q2](https://user-images.githubusercontent.com/927244/102508389-9df77380-4085-11eb-98b5-13634e556fe3.jpg)

