### PR TITLE
add I/O device autoconfig checkbox on s390 (bsc#1168036)

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -2,7 +2,7 @@
 Thu Dec 17 15:13:33 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - add I/O device autoconfig checkbox on s390 (bsc#1168036)
-- 4.2.4
+- 4.3.0
 
 -------------------------------------------------------------------
 Mon Feb 24 15:10:14 CET 2020 - schubi@suse.de

--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 17 15:13:33 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- add I/O device autoconfig checkbox on s390 (bsc#1168036)
+- 4.2.4
+
+-------------------------------------------------------------------
 Mon Feb 24 15:10:14 CET 2020 - schubi@suse.de
 
 - Using SysctlConfig class: Handle sysctl entries in different

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        4.2.4
+Version:        4.3.0
 Release:        0
 Summary:        YaST2 - Hardware Tuning
 License:        GPL-2.0-or-later

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Summary:        YaST2 - Hardware Tuning
 License:        GPL-2.0-or-later

--- a/src/include/hwinfo/system_settings_dialogs.rb
+++ b/src/include/hwinfo/system_settings_dialogs.rb
@@ -31,6 +31,17 @@ module Yast
 
       @contents = VBox("tab")
 
+      # whether to show I/O device autoconfig checkbox
+      has_autoconf = Arch.s390
+
+      kernel_widget_names = ["elevator", "sysrq"]
+      kernel_widgets = [VSpacing(0.3), Left("elevator"), VSpacing(1), Left("sysrq")]
+
+      if has_autoconf
+        kernel_widget_names << "autoconf"
+        kernel_widgets << VSpacing(1) << Left("autoconf")
+      end
+
       @tabs_descr = {
         "pci_id"          => {
           "header"       => NewPCIIDDialogCaption(),
@@ -46,12 +57,12 @@ module Yast
           "contents"     => VBox(
             HBox(
               HSpacing(1),
-              VBox(VSpacing(0.3), Left("elevator"), VSpacing(1), Left("sysrq")),
+              VBox(*kernel_widgets),
               HSpacing(1)
             ),
             VStretch()
           ),
-          "widget_names" => ["elevator", "sysrq"]
+          "widget_names" => kernel_widget_names
         }
       }
 
@@ -138,6 +149,17 @@ module Yast
               "Alt-SysRq-<command_key> will start the respective command (e.g. reboot the\n" +
               "computer, dump kernel information). For further information, see\n" +
               "<tt>/usr/src/linux/Documentation/sysrq.txt</tt> (package kernel-source).</p>\n"
+          )
+        },
+        "autoconf"                    => {
+          "widget" => :checkbox,
+          "label"  => _("Enable I/O device auto-configuration"),
+          "store"  => fun_ref(method(:StoreAutoConfSettings), "void (string, map)"),
+          "init"   => fun_ref(method(:InitAutoConfSettings), "void (string)"),
+          "help"   => _(
+            "<p><b><big>Enable I/O device auto-configuration</big></b><br>\n" +
+            "Disable <b>I/O device auto-configuration</b>\n" +
+            "if you don't want any existing I/O auto-configuration data to be applied.</p>\n"
           )
         }
       }

--- a/src/include/hwinfo/system_settings_ui.rb
+++ b/src/include/hwinfo/system_settings_ui.rb
@@ -161,5 +161,24 @@ module Yast
 
       nil
     end
+
+    def InitAutoConfSettings(key)
+      Wizard.DisableBackButton
+      UI.ChangeWidget(Id("autoconf"), :Value, SystemSettings.GetAutoConf)
+
+      nil
+    end
+
+    def StoreAutoConfSettings(key, event)
+      event = deep_copy(event)
+      Builtins.y2milestone("Key: %1, Event: %2", key, event)
+
+      autoconf_new = Convert.to_boolean(UI.QueryWidget(Id("autoconf"), :Value))
+      if SystemSettings.GetAutoConf != autoconf_new
+        SystemSettings.SetAutoConf(autoconf_new)
+      end
+
+      nil
+    end
   end
 end

--- a/src/modules/SystemSettings.rb
+++ b/src/modules/SystemSettings.rb
@@ -29,6 +29,7 @@ module Yast
       @kernel_sysrq  = nil
       @sysctl_config = nil
       @sysctl_sysrq  = nil
+      @autoconf      = true
       @modified      = false
     end
 
@@ -56,6 +57,7 @@ module Yast
     # @see #read_scheduler
     def Read
       read_sysrq
+      read_autoconf
       ret = read_scheduler
 
       return false unless ret
@@ -67,8 +69,10 @@ module Yast
     #
     # @see #activate_sysrq
     # @see #activate_scheduler
+    # @see #activate_autoconf
     def Activate
       activate_sysrq
+      activate_autoconf
       activate_scheduler
       true
     end
@@ -76,6 +80,7 @@ module Yast
     # Write settings to system configuration
     def Write
       write_sysrq
+      write_autoconf
       write_scheduler
     end
 
@@ -131,6 +136,26 @@ module Yast
       nil
     end
 
+    # Determine current I/O device autoconf setting
+    #
+    # @return [Boolean] true if enabled; false otherwise.
+    def GetAutoConf
+      log.info "GetAutoConf = #{@autoconf}"
+      @autoconf
+    end
+
+    # Set I/O device autoconf status
+    #
+    # @param value [Boolean] true to enable; false to disable
+    def SetAutoConf(value)
+      if value != @autoconf
+        @modified = true
+        @autoconf = value
+      end
+
+      nil
+    end
+
     publish function: :GetPossibleElevatorValues, type: "list <string> ()"
     publish function: :Modified, type: "boolean ()"
     publish function: :Read, type: "boolean ()"
@@ -140,6 +165,8 @@ module Yast
     publish function: :SetIOScheduler, type: "void (string)"
     publish function: :GetSysRqKeysEnabled, type: "boolean ()"
     publish function: :SetSysRqKeysEnabled, type: "void (boolean)"
+    publish function: :GetAutoConf, type: "boolean ()"
+    publish function: :SetAutoConf, type: "void (boolean)"
 
   protected
 
@@ -261,6 +288,17 @@ module Yast
       end
     end
 
+    # Activate I/O device autoconf setting
+    def activate_autoconf
+      if @autoconf
+        log.info("removing rd.zdev kernel parameter")
+        Bootloader.modify_kernel_params("rd.zdev" => :missing)
+      else
+        log.info("adding rd.zdev=no-auto kernel parameter")
+        Bootloader.modify_kernel_params("rd.zdev" => "no-auto")
+      end
+    end
+
     # read available schedulers for the device
     # @param device [String] path to device scheduler file
     # @return [Array<String>] read schedulers from the file
@@ -331,6 +369,25 @@ module Yast
       log.info("Saving ENABLE_SYSRQ: #{enable_sysrq}")
       sysctl_config.kernel_sysrq = enable_sysrq
       sysctl_config.save unless sysctl_config.conflict?
+    end
+
+    # Read I/O device autoconfig settings
+    def read_autoconf
+      rd_zdev = Bootloader.kernel_param(:common, "rd.zdev")
+      log.info "current rd.zdev setting: rd.zdev=#{rd_zdev.inspect}"
+
+      @autoconf = rd_zdev != "no-auto"
+    end
+
+    # Write I/O device autoconfig settings
+    #
+    # This method only has effect during normal mode. During installation,
+    # bootloader configuration is written at the end of the first stage.
+    #
+    # @see Bootloader#Write
+    # @see Write
+    def write_autoconf
+      Bootloader.Write if Mode.normal
     end
 
     # Write IO Scheduler settings

--- a/test/system_settings_test.rb
+++ b/test/system_settings_test.rb
@@ -10,6 +10,7 @@ describe "Yast::SystemSettings" do
 
   subject(:settings) { Yast::SystemSettings }
   let(:scheduler)     { "cfq" }
+  let(:rd_zdev)       { "no-auto" }
   let(:sysctl_config) { CFA::SysctlConfig.new }
 
   before do
@@ -17,6 +18,8 @@ describe "Yast::SystemSettings" do
     allow(Yast::Bootloader).to receive(:Read)
     allow(Yast::Bootloader).to receive(:kernel_param)
       .with(:common, "elevator").and_return(scheduler)
+    allow(Yast::Bootloader).to receive(:kernel_param)
+      .with(:common, "rd.zdev").and_return(rd_zdev)
     allow(CFA::SysctlConfig).to receive(:new).and_return(sysctl_config)
     allow(sysctl_config).to receive(:load)
     allow(sysctl_config).to receive(:save)
@@ -40,6 +43,8 @@ describe "Yast::SystemSettings" do
         .and_return(kernel_sysrq)
       allow(Yast::Bootloader).to receive(:kernel_param)
         .with(:common, "elevator").and_return(scheduler)
+      allow(Yast::Bootloader).to receive(:kernel_param)
+        .with(:common, "rd.zdev").and_return(rd_zdev)
       allow(Yast::Mode).to receive(:mode).and_return(mode)
     end
 
@@ -68,6 +73,24 @@ describe "Yast::SystemSettings" do
       it "uses kernel value" do
         settings.Read
         expect(settings.GetSysRqKeysEnabled).to eq(false)
+      end
+    end
+
+    context "when rd.zdev kernel option is set" do
+      let(:rd_zdev) { "no-auto" }
+
+      it "I/O autoconfig is disabled" do
+        settings.Read
+        expect(settings.GetAutoConf).to eq(false)
+      end
+    end
+
+    context "when rd.zdev kernel option is not set" do
+      let(:rd_zdev) { :missing }
+
+      it "I/O autoconfig is enabled" do
+        settings.Read
+        expect(settings.GetAutoConf).to eq(true)
       end
     end
 
@@ -155,9 +178,11 @@ describe "Yast::SystemSettings" do
     before do
       settings.SetSysRqKeysEnabled(sysrq_keys)
       settings.SetIOScheduler(scheduler)
+      allow(File).to receive(:write).with(KERNEL_SYSRQ_FILE, anything)
       allow(Yast::Bootloader).to receive(:modify_kernel_params)
       allow(Yast::Bootloader).to receive(:proposed_cfg_changed=)
       allow(Dir).to receive(:[]).with(/scheduler/).and_return([disk, disk2])
+      allow(Dir).to receive(:[]).with("/usr/share/YaST2/locale/*").and_return([])
     end
 
     context "when SysRq keys status is unknown" do
@@ -180,6 +205,24 @@ describe "Yast::SystemSettings" do
     context "when SysRq keys is disabled" do
       it "writes '0' to /proc/sys/kernel/sysrq" do
         expect(::File).to receive(:write).with(KERNEL_SYSRQ_FILE, "0\n")
+        settings.Activate
+      end
+    end
+
+    context "when I/O device autoconfig is enabled" do
+      it "removes rd.zdev kernel option" do
+        expect(Yast::Bootloader).to receive(:modify_kernel_params)
+          .with("rd.zdev" => :missing)
+        settings.SetAutoConf(true)
+        settings.Activate
+      end
+    end
+
+    context "when I/O device autoconfig is disabled" do
+      it "sets rd.zdev kernel option to no-auto" do
+        expect(Yast::Bootloader).to receive(:modify_kernel_params)
+          .with("rd.zdev" => "no-auto")
+        settings.SetAutoConf(false)
         settings.Activate
       end
     end


### PR DESCRIPTION
## Task

Port https://github.com/yast/yast-tune/pull/46 to `master`.

## Original Task

Add I/O device autoconfig checkbox to `yast system_settings` client to allow setting the `rd.zdev` kernel option on s390.

Note the default for the autoconfig setting (if there's no kernel option) is `enabled`.

- https://bugzilla.suse.com/show_bug.cgi?id=1168036
- https://trello.com/c/koKlLBHL

## Related

- https://github.com/yast/yast-installation/pull/873

## Screenshots

![q1](https://user-images.githubusercontent.com/927244/102508023-36412880-4085-11eb-9971-246f605e2228.jpg)
![n1](https://user-images.githubusercontent.com/927244/102508037-393c1900-4085-11eb-8e93-8b904452efcf.jpg)