### PR TITLE
remove elevator settings (bsc#1178797)

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 17 16:04:32 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- remove elevator settings (bsc#1178797)
+- 4.3.1
+
+-------------------------------------------------------------------
 Thu Dec 17 15:13:33 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - add I/O device autoconfig checkbox on s390 (bsc#1168036)

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        YaST2 - Hardware Tuning
 License:        GPL-2.0-or-later

--- a/src/include/hwinfo/system_settings_dialogs.rb
+++ b/src/include/hwinfo/system_settings_dialogs.rb
@@ -34,8 +34,8 @@ module Yast
       # whether to show I/O device autoconfig checkbox
       has_autoconf = Arch.s390
 
-      kernel_widget_names = ["elevator", "sysrq"]
-      kernel_widgets = [VSpacing(0.3), Left("elevator"), VSpacing(1), Left("sysrq")]
+      kernel_widget_names = ["sysrq"]
+      kernel_widgets = [VSpacing(1), Left("sysrq")]
 
       if has_autoconf
         kernel_widget_names << "autoconf"
@@ -81,58 +81,6 @@ module Yast
           "handle"        => fun_ref(
             method(:HandleNewPCIIDDialog),
             "symbol (string, map)"
-          )
-        },
-        # /usr/src/linux/Documentation/kernel-parameters.txt
-        # http://www.redhat.com/magazine/008jun05/features/schedulers/
-        #
-        # elevator=    [IOSCHED]
-        #		Format: {"cfq"|"deadline"|"noop"}
-        #		See Documentation/block/as-iosched.txt
-        #		and Documentation/block/deadline-iosched.txt for details.
-        #
-        #	'deadline' =>	Deadline. Database servers, especially those using "TCQ" disks should
-        #			investigate performance with the 'deadline' IO scheduler. Any system with high
-        #			disk performance requirements should do so, in fact.
-        #	'noop' => NOOP
-        #	'cfq' => Completely Fair Queuing (the default)
-        "elevator"                 => {
-          "widget"        => :custom,
-          # combo box label
-          "custom_widget" => ComboBox(
-            Id("elevator"),
-            _("Global &I/O Scheduler"),
-            [
-              # combo box item - I/O scheduler
-              Item(Id(""), _("Not Configured")),
-              # combo box item - I/O scheduler, do not translate the abbreviation in brackets
-              Item(Id("cfq"), _("Completely Fair Queuing [cfq]")),
-              # combo box item - I/O scheduler, do not translate the abbreviation in brackets
-              Item(Id("noop"), _("NOOP [noop]")),
-              # combo box item - I/O scheduler, do not translate the abbreviation in brackets
-              Item(Id("deadline"), _("Deadline [deadline]"))
-            ]
-          ),
-          "handle"        => fun_ref(
-            method(:HandleElevatorSettings),
-            "symbol (string, map)"
-          ),
-          "init"          => fun_ref(
-            method(:InitElevatorSettings),
-            "void (string)"
-          ),
-          "store"         => fun_ref(
-            method(:StoreElevatorSettings),
-            "void (string, map)"
-          ),
-          # help text for the scheduler widget, do not translate 'cfq'
-          "help"          => _(
-            "<p><b><big>Global I/O Scheduler</big></b><br>\n" +
-              "Select the algorithm which orders and sends commands to disk\n" +
-              "devices. This is a global option, it will be used for all disk devices in the\n" +
-              "system. If the option is not configured, the default scheduler (usually 'cfq')\n" +
-              "will be used. See the documentation in the /usr/src/linux/Documentation/block\n" +
-              "directory (package kernel-source) for more information.</p>\n"
           )
         },
         # .sysconfig.sysctl

--- a/src/include/hwinfo/system_settings_ui.rb
+++ b/src/include/hwinfo/system_settings_ui.rb
@@ -119,30 +119,6 @@ module Yast
       :next
     end
 
-
-    def HandleElevatorSettings(key, event)
-      event = deep_copy(event)
-      Builtins.y2milestone("Key: %1, Event: %2", key, event)
-      nil
-    end
-
-    def InitElevatorSettings(value)
-      Wizard.DisableBackButton
-      UI.ChangeWidget(Id("elevator"), :Value, SystemSettings.GetIOScheduler)
-
-      nil
-    end
-
-    def StoreElevatorSettings(key, event)
-      event = deep_copy(event)
-      Builtins.y2milestone("Key: %1, Event: %2", key, event)
-      elevator_new = Convert.to_string(UI.QueryWidget(Id("elevator"), :Value))
-
-      SystemSettings.SetIOScheduler(elevator_new)
-
-      nil
-    end
-
     def InitSysRqSettings(key)
       Wizard.DisableBackButton
       UI.ChangeWidget(Id("sysrq"), :Value, SystemSettings.GetSysRqKeysEnabled)

--- a/src/modules/SystemSettings.rb
+++ b/src/modules/SystemSettings.rb
@@ -24,25 +24,12 @@ module Yast
       Yast.import "Mode"
 
       # Internal Data
-      @elevator      = nil
       @enable_sysrq  = nil
       @kernel_sysrq  = nil
       @sysctl_config = nil
       @sysctl_sysrq  = nil
       @autoconf      = true
       @modified      = false
-    end
-
-    # Known values of the 'elevator' variable
-    ELEVATORS = ["cfq", "noop", "deadline"].freeze
-
-    # Return the possible values to be used as elevators/schedulers
-    #
-    # @return [Array<String>] Know elevators/schedulers
-    #
-    # @see ELEVATORS
-    def GetPossibleElevatorValues
-      ELEVATORS
     end
 
     # Determine if the module was modified
@@ -54,13 +41,11 @@ module Yast
     # Read system settings
     #
     # @see #read_sysrq
-    # @see #read_scheduler
+    # @see #read_autoconf
     def Read
       read_sysrq
       read_autoconf
-      ret = read_scheduler
 
-      return false unless ret
       @modified = false
       true
     end
@@ -68,12 +53,11 @@ module Yast
     # Activate settings
     #
     # @see #activate_sysrq
-    # @see #activate_scheduler
     # @see #activate_autoconf
     def Activate
       activate_sysrq
       activate_autoconf
-      activate_scheduler
+
       true
     end
 
@@ -81,34 +65,8 @@ module Yast
     def Write
       write_sysrq
       write_autoconf
-      write_scheduler
-    end
 
-    # Return the kernel IO scheduler
-    #
-    # The scheduler is specified as the 'elevator' kernel parameter.
-    # If not scheduler is set, it will return an empty string.
-    #
-    # @return [String] IO scheduler name or empty string if not set
-    def GetIOScheduler
-      @elevator
-    end
-
-    # Set IO scheduler
-    #
-    # @param scheduler [String] IO scheduler
-    def SetIOScheduler(scheduler)
-      # empty string = use the default scheduler
-      if valid_scheduler?(scheduler) || scheduler == ""
-        if GetIOScheduler() != scheduler
-          @modified = true
-          @elevator = scheduler
-        end
-      else
-        log.error("unknown IO scheduler '#{scheduler}', use: #{GetPossibleElevatorValues()}")
-      end
-
-      nil
+      true
     end
 
     # Determine if SysRq keys are enabled
@@ -156,13 +114,10 @@ module Yast
       nil
     end
 
-    publish function: :GetPossibleElevatorValues, type: "list <string> ()"
     publish function: :Modified, type: "boolean ()"
     publish function: :Read, type: "boolean ()"
     publish function: :Activate, type: "boolean ()"
     publish function: :Write, type: "boolean ()"
-    publish function: :GetIOScheduler, type: "string ()"
-    publish function: :SetIOScheduler, type: "void (string)"
     publish function: :GetSysRqKeysEnabled, type: "boolean ()"
     publish function: :SetSysRqKeysEnabled, type: "void (boolean)"
     publish function: :GetAutoConf, type: "boolean ()"
@@ -217,39 +172,6 @@ module Yast
       @sysctl_sysrq
     end
 
-    # Determine if a string is a valid scheduler name
-    #
-    # @return [Boolean] true if it's valid; false otherwise.
-    def valid_scheduler?(elevator)
-      GetPossibleElevatorValues().include?(elevator)
-    end
-
-    # Determine the current scheduler from the system
-    #
-    # @return [String] IO Scheduler name; if it's not valid/set, it will return an empty string
-    def current_elevator
-      # get 'elevator' option from the default section
-      elevator_parameter = Bootloader.kernel_param(:common, "elevator")
-      log.info("elevator_parameter: #{elevator_parameter}")
-
-      if elevator_parameter == :missing    # Variable is not set
-        ""
-      elsif elevator_parameter == :present # Variable is set but has not parameter
-        log.info("'elevator' variable has to have some value")
-        ""
-      elsif !valid_scheduler?(elevator_parameter.to_s) # Variable is set but hasn't any known value
-        log.warn(
-          format("'elevator' variable has to have a value from %s instead of being set to %s",
-            GetPossibleElevatorValues(),
-            elevator_parameter
-          )
-        )
-        ""
-      else
-        elevator_parameter.to_s
-      end
-    end
-
     # Activate SysRq keys configuration
     #
     # @see enable_sysrq
@@ -263,31 +185,6 @@ module Yast
       File.write(KERNEL_SYSRQ_FILE, "#{enable_sysrq}\n")
     end
 
-    # Activate IO scheduler
-    #
-    # @see activate_scheduler
-    def activate_scheduler
-      return unless GetIOScheduler()
-
-      new_elevator = GetIOScheduler() == "" ? :missing : GetIOScheduler()
-      log.info("Activating scheduler: #{new_elevator}")
-      # set the scheduler
-      Bootloader.modify_kernel_params("elevator" => new_elevator)
-      # set bootloader configuration as 'changed' (bsc#968192)
-      Bootloader.proposed_cfg_changed = true
-
-      # activate the scheduler for all disk devices
-      return if new_elevator == :missing
-      Dir["/sys/block/*/queue/scheduler"].each do |f|
-        # skip devices which do not support the selected scheduler,
-        # keep the original scheduler
-        next unless device_supports_scheduler(f, new_elevator)
-
-        log.info("Activating scheduler '#{new_elevator}' for device #{f}")
-        File.write(f, new_elevator)
-      end
-    end
-
     # Activate I/O device autoconf setting
     def activate_autoconf
       if @autoconf
@@ -297,50 +194,6 @@ module Yast
         log.info("adding rd.zdev=no-auto kernel parameter")
         Bootloader.modify_kernel_params("rd.zdev" => "no-auto")
       end
-    end
-
-    # read available schedulers for the device
-    # @param device [String] path to device scheduler file
-    # @return [Array<String>] read schedulers from the file
-    def read_device_schedulers(device)
-      schedulers = File.read(device).split(/\s+/).map do |sched|
-        # remove the current scheduler marks [] around the name
-        sched[0] == "[" && sched [-1] == "]" ? sched[1..-2] : sched
-      end
-
-      log.info("Available schedulers for #{device}: #{schedulers}")
-
-      schedulers
-    end
-
-    # does the device support support the scheduler?
-    # @param device [String] path to device scheduler file
-    # @param scheduler [String] name of the requested scheduler
-    # @return [Boolean] true if supported
-    def device_supports_scheduler(device, scheduler)
-      schedulers = read_device_schedulers(device)
-      schedulers.include?(scheduler)
-    end
-
-    # Read IO scheduler configuration updating the module's value
-    #
-    # @see Read
-    #
-    # @return [Boolean] false if there is a problem reading the bootloader; true otherwise
-    def read_scheduler
-      # Try to read the bootloader settings in normal mode.
-      # If there is a problem, the user will be warned directly by the bootloader module.
-      if Mode.normal
-        bootloader_read = Bootloader.Read
-
-        return false unless bootloader_read
-      end
-
-      # Set IO scheduler
-      SetIOScheduler(current_elevator)
-      log.info("Global IO scheduler: #{GetIOScheduler()}")
-
-      true
     end
 
     # Read SysRq keys configuration updating the module's value
@@ -388,18 +241,6 @@ module Yast
     # @see Write
     def write_autoconf
       Bootloader.Write if Mode.normal
-    end
-
-    # Write IO Scheduler settings
-    #
-    # This method only has effect during normal mode. During installation,
-    # bootloader configuration is written at the end of the first stage.
-    #
-    # @see Bootloader#Write
-    # @see Write
-    def write_scheduler
-      Bootloader.Write if Mode.normal
-      true
     end
 
   private

--- a/test/system_settings_test.rb
+++ b/test/system_settings_test.rb
@@ -9,7 +9,6 @@ describe "Yast::SystemSettings" do
   KERNEL_SYSRQ_FILE = "/proc/sys/kernel/sysrq"
 
   subject(:settings) { Yast::SystemSettings }
-  let(:scheduler)     { "cfq" }
   let(:rd_zdev)       { "no-auto" }
   let(:sysctl_config) { CFA::SysctlConfig.new }
 
@@ -17,19 +16,11 @@ describe "Yast::SystemSettings" do
     allow(File).to receive(:exist?).and_return(true)
     allow(Yast::Bootloader).to receive(:Read)
     allow(Yast::Bootloader).to receive(:kernel_param)
-      .with(:common, "elevator").and_return(scheduler)
-    allow(Yast::Bootloader).to receive(:kernel_param)
       .with(:common, "rd.zdev").and_return(rd_zdev)
     allow(CFA::SysctlConfig).to receive(:new).and_return(sysctl_config)
     allow(sysctl_config).to receive(:load)
     allow(sysctl_config).to receive(:save)
     settings.main
-  end
-
-  describe "#GetPossibleElevatorValues" do
-    it "returns an array with possible schedulers" do
-      expect(settings.GetPossibleElevatorValues).to match_array(["cfq", "noop", "deadline"])
-    end
   end
 
   describe "#Read" do
@@ -41,8 +32,6 @@ describe "Yast::SystemSettings" do
       allow(sysctl_config).to receive(:kernel_sysrq).and_return(sysctl_sysrq)
       allow(File).to receive(:read).with(KERNEL_SYSRQ_FILE)
         .and_return(kernel_sysrq)
-      allow(Yast::Bootloader).to receive(:kernel_param)
-        .with(:common, "elevator").and_return(scheduler)
       allow(Yast::Bootloader).to receive(:kernel_param)
         .with(:common, "rd.zdev").and_return(rd_zdev)
       allow(Yast::Mode).to receive(:mode).and_return(mode)
@@ -93,95 +82,16 @@ describe "Yast::SystemSettings" do
         expect(settings.GetAutoConf).to eq(true)
       end
     end
-
-    context "when is in normal mode" do
-      before do
-        allow(Yast::Bootloader).to receive(:Read).and_return(bootloader_read)
-      end
-
-      context "and the bootloader can be read" do
-        let(:bootloader_read) { true }
-
-        it "returns true" do
-          expect(settings.Read).to eq(true)
-        end
-
-        context "when scheduler parameter is missing" do
-          let(:scheduler) { :missing }
-
-          it "unsets IO scheduler" do
-            settings.Read
-            expect(settings.GetIOScheduler).to eq("")
-          end
-        end
-
-        context "when scheduler parameter is present but does not have a value" do
-          let(:scheduler) { :present }
-
-          it "unsets IO scheduler" do
-            settings.Read
-            expect(settings.GetIOScheduler).to eq("")
-          end
-        end
-
-        context "when scheduler parameter has a valid value" do
-          it "sets IO scheduler to that value" do
-            settings.Read
-            expect(settings.GetIOScheduler).to eq(scheduler)
-          end
-        end
-
-        context "when scheduler parameter has an invalid value" do
-          let(:scheduler) { "some-scheduler" }
-
-          it "unsets IO scheduler" do
-            settings.Read
-            expect(settings.GetIOScheduler).to eq("")
-          end
-        end
-
-        it "reads bootloader configuration" do
-          expect(Yast::Bootloader).to receive(:Read)
-          settings.Read
-        end
-      end
-
-      context "but the bootloader cannot be read" do
-        let(:bootloader_read) { false }
-
-        it "returns false" do
-          expect(settings.Read).to eq(false)
-        end
-
-        it "does not set the scheduler" do
-          expect(subject).to_not receive(:SetIOScheduler)
-        end
-      end
-    end
-
-    context "is not in normal mode" do
-      let(:mode) { "installation" }
-
-      it "does not read bootloader configuration" do
-        expect(Yast::Bootloader).to_not receive(:Read)
-        settings.Read
-      end
-    end
   end
 
   describe "#Activate" do
     let(:sysrq_keys) { false }
-    let(:scheduler)  { "" }
-    let(:disk)       { "/sys/block/sda/queue/scheduler" }
-    let(:disk2)      { "/sys/block/sdb/queue/scheduler" }
 
     before do
       settings.SetSysRqKeysEnabled(sysrq_keys)
-      settings.SetIOScheduler(scheduler)
       allow(File).to receive(:write).with(KERNEL_SYSRQ_FILE, anything)
       allow(Yast::Bootloader).to receive(:modify_kernel_params)
       allow(Yast::Bootloader).to receive(:proposed_cfg_changed=)
-      allow(Dir).to receive(:[]).with(/scheduler/).and_return([disk, disk2])
       allow(Dir).to receive(:[]).with("/usr/share/YaST2/locale/*").and_return([])
     end
 
@@ -223,59 +133,6 @@ describe "Yast::SystemSettings" do
         expect(Yast::Bootloader).to receive(:modify_kernel_params)
           .with("rd.zdev" => "no-auto")
         settings.SetAutoConf(false)
-        settings.Activate
-      end
-    end
-
-    context "when a scheduler is set" do
-      let(:scheduler) { "cfq" }
-
-      before do
-        allow(File).to receive(:write).with(KERNEL_SYSRQ_FILE, anything)
-        allow(File).to receive(:read).with(disk).and_return("noop deadline [cfq]")
-        allow(File).to receive(:read).with(disk2).and_return("noop deadline [cfq]")
-      end
-
-      it "updates bootloader configuration" do
-        expect(Yast::Bootloader).to receive(:modify_kernel_params)
-          .with("elevator" => scheduler)
-        expect(Yast::Bootloader).to receive(:proposed_cfg_changed=).with(true)
-        allow(File).to receive(:write)
-        settings.Activate
-      end
-
-      it "activates scheduler for all disk devices" do
-        expect(File).to receive(:write).with(disk, scheduler)
-        expect(File).to receive(:write).with(disk2, scheduler)
-        settings.Activate
-      end
-
-      it "does not activate the scheduler if the device does not support it" do
-        # make the "cfq" scheduler unsupported
-        expect(File).to receive(:read).with(disk2).and_return("[mq-deadline] none")
-        expect(File).to receive(:write).with(disk, scheduler)
-        # ensure it is not changed
-        expect(File).to_not receive(:write).with(disk2, scheduler)
-        settings.Activate
-      end
-    end
-
-    context "when no scheduler is set" do
-      let(:scheduler) { "" }
-
-      before do
-        allow(File).to receive(:write).with(KERNEL_SYSRQ_FILE, anything)
-      end
-
-      it "removes parameter from bootloader configuration" do
-        expect(Yast::Bootloader).to receive(:modify_kernel_params)
-          .with("elevator" => :missing)
-        expect(Yast::Bootloader).to receive(:proposed_cfg_changed=).with(true)
-        settings.Activate
-      end
-
-      it "does not activate scheduler" do
-        expect(File).to_not receive(:write).with(disk, anything)
         settings.Activate
       end
     end
@@ -332,39 +189,6 @@ describe "Yast::SystemSettings" do
       it "does not update sysctl configuration" do
         expect(sysctl_config).to_not receive(:kernel_sysrq=)
         settings.Write
-      end
-    end
-  end
-
-  describe "#SetIOScheduler" do
-    context "when scheduler is a known one" do
-      it "sets the scheduler to the given value" do
-        settings.SetIOScheduler("cfq")
-        expect(settings.GetIOScheduler).to eq("cfq")
-      end
-    end
-
-    context "when scheduler is unknown" do
-      before do
-        settings.SetIOScheduler("cfq")
-      end
-
-      it "does not modify the scheduler" do
-        settings.SetIOScheduler("some-scheduler")
-        expect(settings.GetIOScheduler).to eq("cfq")
-      end
-    end
-
-    context "when new scheduler is different from previous one" do
-      before do
-        allow(Yast::Bootloader).to receive(:kernel_param)
-          .with(:common, "elevator").and_return("cfq")
-        settings.Read
-      end
-
-      it "sets the module as modified" do
-        expect { settings.SetIOScheduler("noop") }.to change { settings.Modified }
-          .from(false).to(true)
       end
     end
   end


### PR DESCRIPTION
## Task

Port https://github.com/yast/yast-tune/pull/48 to `master`.

## Original Task

- https://bugzilla.suse.com/show_bug.cgi?id=1178797
- https://trello.com/c/P1DClkH3

Remove outdated `elevator` kernel option handling.

## Related

- https://github.com/yast/yast-tune/pull/46

## Screenshots
### on non-s390 systems
![q3](https://user-images.githubusercontent.com/927244/102508399-a059cd80-4085-11eb-9a41-2b0929ee1e39.jpg)
### on s390 systems
![q2](https://user-images.githubusercontent.com/927244/102508389-9df77380-4085-11eb-98b5-13634e556fe3.jpg)