### PR TITLE
Fixed Heading if Component Empty or Nil

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 16 13:18:07 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed heading if component is empty or nil (bsc#1193809)
+- Fixed typo in common wizard button ID (:abort, not :bort)
+- 4.4.2
+
+-------------------------------------------------------------------
 Tue Apr 20 18:14:05 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - stop packaging docdir, it only contained the license which

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 Summary:        YaST2 - Hardware Tuning
 License:        GPL-2.0-or-later

--- a/src/clients/inst_hwinfo.rb
+++ b/src/clients/inst_hwinfo.rb
@@ -121,7 +121,7 @@ module Yast
         ret = Convert.to_symbol(UI.UserInput)
       end
 
-      ret = :bort if ret == :close
+      ret = :abort if ret == :close
 
       Wizard.RestoreNextButton
       Wizard.RestoreAbortButton

--- a/src/clients/inst_hwinfo.rb
+++ b/src/clients/inst_hwinfo.rb
@@ -96,9 +96,17 @@ module Yast
         "<P><B>Details</B></P><P>The details of the selected hardware component are displayed here.</P>"
       )
 
-      # heading text, %1 is component name (e.g. "USB UHCI Root Hub")
+      heading =
+        if model.nil? || model.empty?
+          # heading text
+          _("Component Details")
+        else
+          # heading text, %1 is component name (e.g. "USB UHCI Root Hub")
+          Builtins.sformat(_("Component '%1'"), model)
+        end
+
       Wizard.SetContents(
-        Builtins.sformat(_("Component '%1'"), model),
+        heading,
         content,
         help_text,
         true,

--- a/src/clients/inst_hwinfo.rb
+++ b/src/clients/inst_hwinfo.rb
@@ -39,7 +39,7 @@ module Yast
       #
       #************************************
 
-      # aliases for wizard sequncer
+      # aliases for wizard sequencer
       @aliases = {
         "detected" => lambda { detected_dialog },
         "details"  => [lambda { details_dialog(@selected_model, @selected_info) }, true],


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1193809


## Problem

Weird heading in HW info during installation if one of the component names is empty.

![broken-heading](https://user-images.githubusercontent.com/11538225/146379499-8410326f-eb85-4826-82e8-2fe2fc8cd4ec.png)

This may appear only during interactive HW probing when the components are probed one by one.


## Fix

Use a different headline if `model` (the component name) is nil or empty.

![component-empty-or-nil](https://user-images.githubusercontent.com/11538225/146379803-ff6528fa-b917-4582-a85d-6676c8111443.png)

_Empty / nil component name (artificially forced with a `model = nil` or `model = ""` code line)_

![component-has-value](https://user-images.githubusercontent.com/11538225/146379935-7ca85a27-e03b-4965-bd6c-759c7456b1a1.png)

_Normal case: The component has a name._


## How to Invoke

As _root_ in the installed system:

```
/usr/lib/YaST2/bin/y2start /usr/share/YaST2/clients/inst_hwinfo.rb qt
```
