### PR TITLE
Added Runtime Dependency on hwinfo

### DIFF
--- a/package/yast2-tune.changes
+++ b/package/yast2-tune.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 24 09:52:36 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added runtime dependency on hwinfo (bsc#1202651)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-tune.spec
+++ b/package/yast2-tune.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-tune
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - Hardware Tuning
 License:        GPL-2.0-or-later

--- a/src/clients/hwinfo.rb
+++ b/src/clients/hwinfo.rb
@@ -22,6 +22,9 @@ module Yast
       Yast.import "Directory"
       Yast.import "CommandLine"
       Yast.import "Icon"
+      Yast.import "Package"
+      Yast.import "Mode"
+      Yast.import "Report"
 
       #include "hwinfo/classnames.ycp";
       Yast.include self, "hwinfo/routines.rb"
@@ -54,7 +57,7 @@ module Yast
         "guihandler" => fun_ref(method(:StartGUI), "symbol ()")
       }
 
-      CommandLine.Run(@cmdline_description) 
+      CommandLine.Run(@cmdline_description)
 
 
       # EOF
@@ -159,7 +162,7 @@ module Yast
                 )
               )
             )
-          end 
+          end
 
 
           # add processor index
@@ -235,7 +238,7 @@ module Yast
 
         Builtins.foreach(dir) do |d|
           uniq = Builtins.add(uniq, d) if !Builtins.contains(uniq, d)
-        end 
+        end
 
 
         dir = deep_copy(uniq)
@@ -284,9 +287,25 @@ module Yast
       end
     end
 
+    # Check if the "hwinfo" package or binary is available and possibly offer
+    # to install it.
+    #
+    # @return [Boolean] true if success, false if error
+    #
+    def ensure_hwinfo_available
+      return true unless Mode.normal
+
+      return true if Package.CheckAndInstallPackages(["hwinfo"])
+
+      Report.Error(Message.CannotContinueWithoutPackagesInstalled)
+      false
+    end
+
 
     # Main
     def StartGUI
+      return :back unless ensure_hwinfo_available
+
       # display progress popup
       OpenProbingPopup()
 


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1202651


## Trello

https://trello.com/c/0AVVwBSV


## Problem

One of the two .desktop files of the yast2-tune package needs the `hwinfo` binary to run, otherwise it just closes without any information what went wrong.


## Fix

Added a dynamic runtime check upon startup of the `yast2 hwinfo` module:

- Check if the `hwinfo` package is installed
- Ask the user if it should be installed
- If the user answers "no" or aborts, or if installing the package fails, report an error (using the `Report` module) and close the `yast2 hwinfo` module.


## Test

Manual test in an up-to-date Tumbleweed with uninstalling the `hwinfo` package first.
